### PR TITLE
Mike/atl 3172/raise publish exceptions

### DIFF
--- a/lib/tiki/torch/config.rb
+++ b/lib/tiki/torch/config.rb
@@ -39,6 +39,10 @@ module Tiki
       attribute :events_sleep_times, Hash, default: EVENT_SLEEP_TIMES
       attribute :serialization_strategy, String, default: SerializationStrategies::PREFIX
       attribute :valid_formats, Array, default: YAML_CODES.concat(JSON_CODES)
+      # Can be anything that responds to `call`. Defaults to noop.
+      # Virtus automatically calls anything that responds to `call`, so we have to wrap the
+      # handler in a lambda.
+      attribute :publishing_error_handler, Object, default: lambda { |_, _| Proc.new { |_| } }
 
       def default_message_properties
         @default_message_properties ||= {}

--- a/lib/tiki/torch/config.rb
+++ b/lib/tiki/torch/config.rb
@@ -42,7 +42,7 @@ module Tiki
       # Can be anything that responds to `call`. Defaults to noop.
       # Virtus automatically calls anything that responds to `call`, so we have to wrap the
       # handler in a lambda.
-      attribute :publishing_error_handler, Object, default: lambda { |_, _| Proc.new { |_| } }
+      attribute :publishing_error_handler, Object, default: lambda { |_, _| Proc.new { |_, _, _| } }
 
       def default_message_properties
         @default_message_properties ||= {}

--- a/lib/tiki/torch/publishing/publisher.rb
+++ b/lib/tiki/torch/publishing/publisher.rb
@@ -6,6 +6,8 @@ module Tiki
         include Logging
         extend Forwardable
 
+        PublishingError = Class.new(::StandardError)
+
         def publish(topic_name, event)
           log_debug(topic_name, event)
           queue_name, event = build_queue_name(topic_name, event)
@@ -15,7 +17,8 @@ module Tiki
           res
         rescue StandardError => e
           log_exception e, section: 'publisher', topic: topic_name
-          raise
+
+          raise(PublishingError, e)
         end
 
         def to_s

--- a/lib/tiki/torch/publishing/publisher.rb
+++ b/lib/tiki/torch/publishing/publisher.rb
@@ -6,8 +6,6 @@ module Tiki
         include Logging
         extend Forwardable
 
-        PublishingError = Class.new(::StandardError)
-
         def publish(topic_name, event)
           log_debug(topic_name, event)
           queue_name, event = build_queue_name(topic_name, event)
@@ -15,10 +13,10 @@ module Tiki
           monitor_publish(topic_name, event.payload, event.properties)
           debug_var(:res, res)
           res
-        rescue StandardError => e
+        rescue Exception => e
           log_exception e, section: 'publisher', topic: topic_name
 
-          raise(PublishingError, e)
+          Torch.config.publishing_error_handler.call(e)
         end
 
         def to_s

--- a/lib/tiki/torch/publishing/publisher.rb
+++ b/lib/tiki/torch/publishing/publisher.rb
@@ -13,8 +13,9 @@ module Tiki
           monitor_publish(topic_name, event.payload, event.properties)
           debug_var(:res, res)
           res
-        rescue Exception => e
+        rescue StandardError => e
           log_exception e, section: 'publisher', topic: topic_name
+          raise
         end
 
         def to_s

--- a/lib/tiki/torch/publishing/publisher.rb
+++ b/lib/tiki/torch/publishing/publisher.rb
@@ -16,7 +16,7 @@ module Tiki
         rescue Exception => e
           log_exception e, section: 'publisher', topic: topic_name
 
-          Torch.config.publishing_error_handler.call(e)
+          Torch.config.publishing_error_handler.call(e, topic_name, event)
         end
 
         def to_s

--- a/lib/tiki/torch/version.rb
+++ b/lib/tiki/torch/version.rb
@@ -1,5 +1,5 @@
 module Tiki
   module Torch
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/spec/unit/publishing/publisher_spec.rb
+++ b/spec/unit/publishing/publisher_spec.rb
@@ -46,6 +46,30 @@ module Tiki
             end
           end
 
+          context "with a StandardError raised" do
+            let(:event) { Message.new(payload, props, "json", "message_attributes") }
+            before do
+              allow(Torch.client).to receive(:queue).with("fantastic-cheese-events").and_return(mock_queue)
+              allow(mock_queue).to receive(:send_message).and_raise(StandardError, "test error")
+            end
+
+            it "should log and re-raise the exception" do
+              expect(subject).to receive(:log_exception)
+              expect { subject.publish("cheese", event) }.to raise_error(StandardError)
+            end
+          end
+
+          context "with a low-level exception raised" do
+            let(:event) { Message.new(payload, props, "json", "message_attributes") }
+            before do
+              allow(Torch.client).to receive(:queue).with("fantastic-cheese-events").and_return(mock_queue)
+              allow(mock_queue).to receive(:send_message).and_raise(Exception, "test error")
+            end
+
+            it "should not swallow the exception" do
+              expect { subject.publish("cheese", event) }.to raise_error(Exception)
+            end
+          end
         end
       end
     end

--- a/spec/unit/publishing/publisher_spec.rb
+++ b/spec/unit/publishing/publisher_spec.rb
@@ -63,7 +63,7 @@ module Tiki
 
             context "with an error handler configured" do
               before do
-                allow(Torch.config).to receive(:publishing_error_handler).and_return(Proc.new {|error| raise error})
+                allow(Torch.config).to receive(:publishing_error_handler).and_return(Proc.new {|error, topic, event| raise error})
               end
 
               it "should log and re-raise the error" do

--- a/spec/unit/publishing/publisher_spec.rb
+++ b/spec/unit/publishing/publisher_spec.rb
@@ -53,9 +53,9 @@ module Tiki
               allow(mock_queue).to receive(:send_message).and_raise(StandardError, "test error")
             end
 
-            it "should log and re-raise the exception" do
+            it "should log and re-raise a PublishingError" do
               expect(subject).to receive(:log_exception)
-              expect { subject.publish("cheese", event) }.to raise_error(StandardError)
+              expect { subject.publish("cheese", event) }.to raise_error(described_class::PublishingError)
             end
           end
 


### PR DESCRIPTION
### Ticket
https://jira.smpl.ch/browse/ATL-3172

### Description
After a couple of months of dealing with missing onboards to LMS, we found that a group of missing onboards coincided with a network failure. Digging deeper, I discovered that publishing in Tiki::Torch was always ignoring errors, which meant no possibility for catching problems at publish time.

This change allows errors to be raised to the calling code. Note that code publishing using Tiki::Torch will now have to handle exceptions! If you don't like this change, please let me know.
However, the opposite seems worse to me: why would we ever want to fail publishing and have no idea?

I've assigned a reviewer from each team that I know is using the library. I'm very open to feedback!

### Testing instructions
I don't think there is an easy way to manually test. I have added unit tests to exercise the changed code.