### PR TITLE
Hector/lms 8305/aws sdk sqs

### DIFF
--- a/lib/tiki/torch.rb
+++ b/lib/tiki/torch.rb
@@ -16,7 +16,7 @@ require 'forwardable'
 require 'colorize'
 require 'yaml'
 require 'logger'
-require 'aws-sdk-core'
+require 'aws-sdk-sqs'
 require 'zlib'
 
 require 'tiki/torch/version'

--- a/lib/tiki/torch/version.rb
+++ b/lib/tiki/torch/version.rb
@@ -1,5 +1,5 @@
 module Tiki
   module Torch
-    VERSION = '0.1.3'
+    VERSION = '0.1.4'
   end
 end

--- a/tiki_torch.gemspec
+++ b/tiki_torch.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.add_dependency 'aws-sdk-core', '~> 2.5.8'
+  s.add_dependency 'aws-sdk-sqs', '~> 1'
   s.add_dependency 'concurrent-ruby', '~> 1.0'
   s.add_dependency 'concurrent-ruby-edge'
   s.add_dependency 'lifeguard', '0.3.0'


### PR DESCRIPTION
## Jira Ticket
https://jira.smpl.ch/browse/LMS-8305

## Description
The main purpose of this PR is to get master in a state where it can be updated and allow master to be used. It appears that all projects that are using this gem are using the `aws_sdk_v3` branch in prod. That branch was merged into master [here](https://github.com/acima-credit/tiki_torch/commit/d6e80d567b6cf6f6729a534977b3c94e73046ab2). After reviewing the commits on this project I discovered that `'aws-sdk-sqs'` dependency was changed back to `'aws-sdk-core'` in master [here](https://github.com/acima-credit/tiki_torch/commit/de4f790774a4dadf13814ecc9aa87212b3aafea3). 

Also the commit history is a bit messy in this project. Since this a shared project, I propose we use the `squash and merge` github feature when merging PRs and all PR's go through the pull request process.

I have tested onboarding from merchant portal to LMS, SMS messages LMS, and document uploading in LMS without any issues. 

