### PR TITLE
Add lms custom version since version does not match master

### DIFF
--- a/lib/tiki/torch/version.rb
+++ b/lib/tiki/torch/version.rb
@@ -1,5 +1,5 @@
 module Tiki
   module Torch
-    VERSION = '0.1.1'
+    VERSION = '0.1.1.lms'
   end
 end


### PR DESCRIPTION
This explicitly creates a lms version (0.1.1.lms) since it's different than master 0.1.1. Merging will effect the current lms setup as it will change the version in the Gemfile.lock on lms.