### PR TITLE
Add patch for YAML in instances of RUBY 3 or greater

### DIFF
--- a/.github/workflows/publish-on-push.yaml
+++ b/.github/workflows/publish-on-push.yaml
@@ -1,0 +1,15 @@
+name: Publish Ruby Gem (Pushed)
+
+on:
+  push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and publish gem
+        uses: jstastny/publish-gem-to-github@v2.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: acima-credit

--- a/lib/tiki/torch/config.rb
+++ b/lib/tiki/torch/config.rb
@@ -36,6 +36,7 @@ module Tiki
 
       attribute :event_pool_size, Integer, default: lambda { |_, _| Concurrent.processor_count }
       attribute :transcoder_code, String, default: 'yaml'
+      attribute :permitted_classes_for_YAML, Array, default: lambda { |_, _| [Symbol, Time, Date, DateTime, BigDecimal] }
       attribute :events_sleep_times, Hash, default: EVENT_SLEEP_TIMES
       attribute :serialization_strategy, String, default: SerializationStrategies::PREFIX
 

--- a/lib/tiki/torch/consumers/settings.rb
+++ b/lib/tiki/torch/consumers/settings.rb
@@ -69,6 +69,10 @@ module Tiki
             @transcoder_code || Torch.config.transcoder_code
           end
 
+          def permitted_classes_for_YAML
+            @permitted_classes_for_YAML || Torch.config.permitted_classes_for_YAML
+          end
+
           def serialization_strategy
             @serialization_strategy || Torch.config.serialization_strategy
           end

--- a/lib/tiki/torch/transcoders/yaml.rb
+++ b/lib/tiki/torch/transcoders/yaml.rb
@@ -14,7 +14,7 @@ module Tiki
           if RUBY_VERSION[0].to_i < 3
             YAML.load(str)
           else
-            YAML.load(str, permitted_classes: [OpenStruct, Symbol, Time])
+            YAML.load(str, permitted_classes: Torch.config.permitted_classes_for_YAML)
           end
         end
       end

--- a/lib/tiki/torch/transcoders/yaml.rb
+++ b/lib/tiki/torch/transcoders/yaml.rb
@@ -1,9 +1,7 @@
 module Tiki
   module Torch
     class YamlTranscoder < Transcoder
-
       class << self
-
         def codes
           Torch::Config::YAML_CODES
         end
@@ -13,11 +11,13 @@ module Tiki
         end
 
         def decode(str)
-          YAML.load(str)
+          if RUBY_VERSION[0].to_i < 3
+            YAML.load(str)
+          else
+            YAML.load(str, permitted_classes: [OpenStruct, Symbol, Time])
+          end
         end
-
       end
-
     end
   end
 end

--- a/lib/tiki/torch/version.rb
+++ b/lib/tiki/torch/version.rb
@@ -1,5 +1,5 @@
 module Tiki
   module Torch
-    VERSION = '0.1.4'
+    VERSION = '0.1.5'
   end
 end

--- a/tiki_torch.gemspec
+++ b/tiki_torch.gemspec
@@ -4,8 +4,10 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'tiki/torch/version'
 
 Gem::Specification.new do |s|
-  s.name        = 'tiki_torch'
-  s.version     = Tiki::Torch::VERSION
+  s.name = 'tiki_torch'
+  current_branch = `git branch --remote --contains | sed "s|[[:space:]]*origin/||"`.strip
+  branch_commit = `git rev-parse HEAD`.strip[0..6]
+  s.version     = current_branch == 'master' ? Tiki::Torch::VERSION : "#{Tiki::Torch::VERSION}-#{branch_commit}"
   s.authors     = ['Adrian Madrid']
   s.email       = ['aemadrid@gmail.com']
   s.description = %q{Inter-service communication library for Ruby}


### PR DESCRIPTION
In order for the use of tiki_torch with ruby 3 we need to add permitted_classes to the YAML.load due to their upgrade to PSYCH 4 