### PR TITLE
UW-3473 - Fix logging of unsupported attribute data types

### DIFF
--- a/.github/workflows/publish-on-push.yaml
+++ b/.github/workflows/publish-on-push.yaml
@@ -1,15 +1,15 @@
-name: Publish Ruby Gem (Pushed)
+name: Publish Ruby Gem To GitHub Packages (Pushed)
 
-on:
-  push
+on: push
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build and publish gem
-        uses: jstastny/publish-gem-to-github@v2.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          owner: acima-credit
+  build-and-push:
+    name: Build And Push Gems
+    uses: upbound-group/ruby-actions/.github/workflows/reusable_push_gems.yml@main  # locking to `main` branch for latest updates for now
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+    with:
+      registry-url: "https://rubygems.pkg.github.com/acima-credit"
+      use-github-token-as-bearer-token: true

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Master is a backwards-compatible TikiTorch branch that has been augmented for use with Amazon SQS attributes. It can consume and produce messages in the prefix-style notation, and the API should also be backwards compatible (when changing to the new version in Merchant Portal, we did have to modify the way some of the test helpers worked). The widely-used branch at https://github.com/aemadrid/tiki_torch/tree/feature/move_to_sqs has been tagged as v0.0.3 here. Previous incarnations have been versioned and tagged (version 0.0.1 is the Rabbit MQ implementation, and versions starting with v0.0.3 are Amazon SQS based).
 
-TODO: Write a gem description
+TODO: Write a gem description soon
 
 ## Installation
 

--- a/lib/tiki/torch/serialization/attributes_strategy.rb
+++ b/lib/tiki/torch/serialization/attributes_strategy.rb
@@ -2,6 +2,7 @@ module Tiki
   module Torch
     module Serialization
       class AttributesStrategy
+        include Logging
 
         class << self
 
@@ -41,7 +42,7 @@ module Tiki
           def get_message_attributes(attributes)
             attributes.each_with_object({}) do |(k,v), hsh|
               if v.data_type.downcase != "string"
-                log_info("Unsupported attribute type: #{v.data_type}")
+                info("Unsupported attribute type: #{v.data_type}")
                 next
               end
               key = k.underscore.to_sym

--- a/lib/tiki/torch/version.rb
+++ b/lib/tiki/torch/version.rb
@@ -1,5 +1,5 @@
 module Tiki
   module Torch
-    VERSION = '0.1.7'
+    VERSION = '0.1.8'
   end
 end


### PR DESCRIPTION
### Ticket
[UW-3473](https://acima.atlassian.net/browse/UW-3473)

### Desription

At some point MP added a new message attribute `location_api_partner_ids` which is an array of strings.  This currently is unsupported by Tiki and results in a call to non-existent `log_Info` call when it cannot be parsed.

This DOES NOT fix the fact that tiki does not currently support this data.  This PR just fixes the logging such that exceptions are not tossed such that I can continue on with Concora 2b changes.

This also fixes publishing of gems the new upbound way

[UW-3473]: https://acima.atlassian.net/browse/UW-3473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ